### PR TITLE
A few additional improvements to make it more robust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 localtest.bat
+stash_interface.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+localtest.bat


### PR DESCRIPTION
Since your version was ahead of the original, I've made ammendmends to yours.

I've added support for Jellyfin cover art (since it uses `<art />` elements instead of `<fanart />`, as well as made your poster download to local files more robust - your version assumed the image to be JPEG, while this isn't necessarily true. Mine are WEBP, for instance.